### PR TITLE
Fix wrong handling of stock prices exceeding 1000

### DIFF
--- a/examples/timelineCsvConverter.py
+++ b/examples/timelineCsvConverter.py
@@ -25,8 +25,8 @@ with open('companyNameIsins.json', 'r', encoding='utf-8') as f:
 # Extract decimal number in a string
 def getDecimalFromString(inputString):
     try:
-        numbers = re.findall('[-+]?\d*\,\d+|\d+', inputString)
-        return numbers[0].replace(",",".")
+        numbers = re.findall('[-+]?\d.*\,\d+|\d+', inputString)
+        return numbers[0].replace(".","").replace(",",".")
     except:
         return None
     return None


### PR DESCRIPTION
The regex expression to extract the unitary value of each stock doesn't treat the case when unitary stock price exceeds 1000.
Current expression separates the value into 2 matches:
Example: Value = 2,613.00 EUR => Regex Result  [ 2 , 613.00 ] which renders stock value = 2 at the end

![image](https://user-images.githubusercontent.com/30177196/120096447-e4202b00-c12b-11eb-9649-7559340b3a03.png)
